### PR TITLE
allow for shared or global model extension when rendering all ingredi…

### DIFF
--- a/lib/middleware/preview.js
+++ b/lib/middleware/preview.js
@@ -96,6 +96,7 @@ function previewMiddleware(config, req, res, next) {
 							decodeURIComponent(req.query.modelPath)
 						);
 					}
+
 					return model;
 				}());
 
@@ -175,15 +176,20 @@ function previewMiddleware(config, req, res, next) {
 					previewFnPromise,
 					handlebarsPromise,
 					function (model, previewFn) {
-						// return the rendered preview
-						return previewFn({
+						var renderModel = {
 							ingredientName: ingredient.name,
 							hasStyles: !!ingredient.entryPoints.sass ||
 								!!ingredient.entryPoints.less,
 							hasScript: !!ingredient.entryPoints.javaScript ||
 								!!ingredient.entryPoints.previewScript,
 							model: model
-						});
+						};
+						if (config.basePreviewModel) {
+							_.extend(renderModel, config.basePreviewModel);
+						}
+
+						// return the rendered preview
+						return previewFn(renderModel);
 					}
 				);
 			})
@@ -208,6 +214,9 @@ function previewMiddleware(config, req, res, next) {
  *   is used.
  * @param {Object} [config.helpers] - optional map of Handlebars helpers to
  *   register
+ * @param {Object} [config.basePreviewModel] - optional model that will be extended
+ *   into the root object before rendering. If your ingredients contain @root
+ *   references, you'll want to specify those things here.
  * @param {Function} [callback] - optional node-style callback that will be
  *   called when the middleware is fully initialized and will respond to
  *   requests
@@ -223,6 +232,13 @@ function initPreviewMiddleware(config, callback) {
 		assert.ok(
 			_.isObject(config.defaultModel),
 			'config.defaultModel must be an object'
+		);
+	}
+
+	if ('basePreviewModel' in config) {
+		assert.ok(
+			_.isObject(config.basePreviewModel),
+			'config.basePreviewModel must be an object'
 		);
 	}
 


### PR DESCRIPTION
There may be cases where you want to specify global model properties that are always included when rendering a preview, regardless of ingredient.

This change makes that possible.