### PR TITLE
Passing through predicates from config

### DIFF
--- a/lib/middleware/preview.js
+++ b/lib/middleware/preview.js
@@ -262,7 +262,8 @@ function initPreviewMiddleware(config, callback) {
 
 	var pantryPromise = roux.initialize({
 		name: config.name,
-		path: config.path
+		path: config.path,
+		predicates: config.predicates
 	});
 
 	if (callback) {


### PR DESCRIPTION
To enable the preview page to recognise predicates coming from the config file in Bechamel.
Another alternative would be just pass the whole config object as argument, i.e.: `roux.initialize(config)`.